### PR TITLE
Avoid referencing undeclared nil settings

### DIFF
--- a/vis-filetype-settings.lua
+++ b/vis-filetype-settings.lua
@@ -26,6 +26,7 @@
 -- filetype, leading to an infinite loop.
 
 vis.events.subscribe(vis.events.WIN_OPEN, function(win)
+	if settings == nil then return end
 	local window_settings = settings[win.syntax]
 
 	if type(window_settings) == "table" then


### PR DESCRIPTION
This change handles the case where you just require("vis-filetype-settings") without declaring the `settings` global variable.